### PR TITLE
Allow use of Laravel 4.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.1.*"
+        "illuminate/support": "4.*"
     },
     "require-dev": {
         "phpspec/phpspec": "2.0.*@dev"
@@ -20,5 +20,5 @@
             "Laracasts\\Utilities": "src/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
I assume that updating to Laravel 4.2.x won't break anything !
It is because I would really like to use the new traits features in Laravel 4.2 :)

Thanks for this simple but awesome package !
