### PR TITLE
Adding PHP <= 5.3 compatibility.

### DIFF
--- a/src/Laracasts/Utilities/UtilitiesServiceProvider.php
+++ b/src/Laracasts/Utilities/UtilitiesServiceProvider.php
@@ -50,7 +50,7 @@ class UtilitiesServiceProvider extends ServiceProvider {
      */
     public function provides()
     {
-        return ['JavaScript'];
+        return array('JavaScript');
     }
 
 }


### PR DESCRIPTION
Replacing PHP 5.4 array short notation with the traditional one to support PHP versions < 5.4
