### PR TITLE
Adding info about the path to the view in config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,9 @@ return [
 #### bind_js_vars_to_this_view
 
 You need to update this file to specify which view you want the new transformed JavaScript variables to be prepended to. Typically, your footer is a good place for this.
-If you include something like a `layouts/partials/footer` partial, where you store your footer and script references, then make the `bind_js_vars_to_this_view` key equal to that path. Behind the scenes, the Laravel implementation of this package will listen for when that view is composed, and essentially paste the JS variables within it.
+If you include something like a `layouts/partials/footer` partial, where you store your footer and script references, then make the `bind_js_vars_to_this_view` key equal to that path. **Warning**: you should specify the view like `layouts/partials/footer` and not `layouts.partials.footer`.
+
+Behind the scenes, the Laravel implementation of this package will listen for when that view is composed, and essentially paste the JS variables within it.
 
 #### js_namespace
 


### PR DESCRIPTION
You shouldn't specify the path to the view using the "object oriented" syntax for view. 'bind_js_vars_to_this_view' => 'layouts/footer' works but 'bind_js_vars_to_this_view' => 'layouts.footer' doesn't.

I changed the README file to include this info.
