### PR TITLE
replaced json_encode with recursive array/object-literal encoding

### DIFF
--- a/src/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformer.php
+++ b/src/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformer.php
@@ -135,8 +135,37 @@ class PHPToJavaScriptTransformer {
     {
         if (is_array($value))
         {
-            return json_encode($value);
+            $array = array_map(function($entry) { return $this->optimizeValueForJavaScript($entry); }, $value);
+
+            if (array_keys($array) === range(0, count($array) - 1)) {
+                return $this->encodeSequentialArray($array);
+            }
+            else {
+                return $this->encodeAssociativeArray($array);
+            }
         }
+    }
+
+    /**
+     * @param  array  $array
+     * @return string
+     */
+    protected function encodeSequentialArray(array $array) {
+        return '[' . implode(', ', $array) . ']';
+    }
+
+    /**
+     * @param  array  $array
+     * @return string
+     */
+    protected function encodeAssociativeArray(array $array) {
+        $objectLiteral = '{ ';
+
+        foreach ($array as $key => $value) {
+            $objectLiteral .= "{$key}: $value, ";
+        }
+
+        return $objectLiteral . ' }';
     }
 
     /**


### PR DESCRIPTION
I encountered a problem with json_encode in that it cannot echo object literals or raw expressions (eg, functions or variable names).

This will recursively create object literals or arrays as necessary.

If you're interested, I can share my raw expression modifications as well. The syntax I'm using is `JavaScript::raw("function(x) { return x * x; }");`