### PR TITLE
Allow 5.0.x while it's under development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0"
+        "illuminate/support": "~4.0|5.0.x"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0"
@@ -20,5 +20,6 @@
         "psr-0": {
             "Laracasts\\Utilities": "src/"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Laravel 5.0 is still under development and this pull request enables to use your package with the new version of the framework.