### PR TITLE
Handle values of the type stdClass, which plays nicely with json_encode

### DIFF
--- a/spec/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformerSpec.php
+++ b/spec/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformerSpec.php
@@ -56,9 +56,16 @@ class PHPToJavaScriptTransformerSpec extends ObjectBehavior
             ->shouldMatch('/window.age = null;window.sum = null;/');
     }
 
-    function it_throws_an_exception_if_an_object_cant_be_transformed(\StdClass $obj)
+    function it_throws_an_exception_if_an_object_cant_be_transformed(\Laracasts\Utilities\JavaScript\PHPToJavaScriptTransformer $obj)
     {
         $this->shouldThrow('Exception')
             ->duringBuildJavaScriptSyntax(['foo' => $obj]);
     }
+
+    function it_does_not_throw_an_exception_for_stdClass(\StdClass $obj)
+    {
+        $this->buildJavaScriptSyntax(['foo' => $obj])
+            ->shouldMatch('/window.window = window.window || {};/');
+    }
+
 }

--- a/src/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformer.php
+++ b/src/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformer.php
@@ -1,6 +1,7 @@
 <?php namespace Laracasts\Utilities\JavaScript;
 
 use Exception;
+use stdClass;
 
 class PHPToJavaScriptTransformer {
 
@@ -22,7 +23,7 @@ class PHPToJavaScriptTransformer {
      * @var array
      */
     protected $types = [
-        'String', 'Array', 'Object', 'Numeric', 'Boolean', 'Null'
+        'String', 'Array', 'stdClass', 'Object', 'Numeric', 'Boolean', 'Null'
     ];
 
     /**
@@ -160,6 +161,19 @@ class PHPToJavaScriptTransformer {
         if (is_bool($value))
         {
             return $value ? 'true' : 'false';
+        }
+    }
+
+    /**
+     * @param $value
+     * @return string
+     * @throws \Exception
+     */
+    protected function transformstdClass($value)
+    {
+        if ($value instanceof stdClass)
+        {
+            return json_encode($value);
         }
     }
 


### PR DESCRIPTION
While most objects need special handling with `toJson` or `__toString`, instances of `stdClass` will work directly with `json_encode()`.

This check runs before the check for `Object` since every `stdClass` is also an `Object`.