### PR TITLE
Add transform to Angular Constant

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,9 +75,7 @@ public function index()
 Using the code above, the following will be outputted (assuming you defined `myApp` as your module in the config).
 
 ```js
-angular.module('myApp')
-    .constant('foo', 'bar')
-    .constant('age': 29);
+angular.module('myApp').constant('DATA', {'foo', 'bar', 'age': 29});
 ```
 
 ### Defaults
@@ -129,7 +127,17 @@ return [
     | This will also activate the Angular service.
     |
     */
-    'ng_module' => false
+    'ng_module' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Angular Constant Name
+    |--------------------------------------------------------------------------
+    |
+    | The name of the Angular constant we are attaching the data to.
+    |
+    */
+    'ng_constant' => 'DATA'
 
 ];
 ```

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,28 @@ console.log(user); // User Obj
 console.log(age); // 29
 ```
 
+If you've also defined an Angular module in your config, you'll gain access to the `Angular` facade, which you may use in your controllers.
+
+```php
+public function index()
+{
+    Angular::put([
+        'foo' => 'bar',
+        'age' => 29
+    ]);
+
+    return View::make('hello');
+}
+```
+
+Using the code above, the following will be outputted (assuming you defined `myApp` as your module in the config).
+
+```js
+angular.module('myApp')
+    .constant('foo', 'bar')
+    .constant('age': 29);
+```
+
 ### Defaults
 
 If using Laravel, there are only two configuration options that you'll need to worry about. First, publish the default configuration.
@@ -94,7 +116,20 @@ return [
     | That way, you can access vars, like "SomeNamespace.someVariable."
     |
     */
-    'js_namespace' => 'window'
+    'js_namespace' => 'window',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Angular Module
+    |--------------------------------------------------------------------------
+    |
+    | By default, we disable the Angular constants service. If you would like
+    | to export your PHP vars to Angular constants, you will want to change
+    | this to the Angular module that you want to bind your constants to.
+    | This will also activate the Angular service.
+    |
+    */
+    'ng_module' => false
 
 ];
 ```

--- a/src/AngularFacade.php
+++ b/src/AngularFacade.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Laracasts\Utilities\JavaScript;
+
+use Illuminate\Support\Facades\Facade;
+
+class AngularFacade extends Facade
+{
+
+    /**
+     * The name of the binding in the IoC container.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'Angular';
+    }
+}

--- a/src/JavascriptServiceProvider.php
+++ b/src/JavascriptServiceProvider.php
@@ -29,6 +29,21 @@ class JavaScriptServiceProvider extends ServiceProvider
 
             return new PHPToJavaScriptTransformer($binder, $namespace);
         });
+
+        if(config('javascript.ng_module')) {
+            $this->app->bind('Angular', function ($app) {
+                $view = config('javascript.bind_js_vars_to_this_view');
+                $module = config('javascript.ng_module');
+
+                if (is_null($view)) {
+                    throw new JavaScriptException;
+                }
+
+                $binder = new LaravelViewBinder($app['events'], $view);
+
+                return new PHPToAngularTransformer($binder, $module);
+            });
+        }
     }
 
     /**
@@ -44,6 +59,13 @@ class JavaScriptServiceProvider extends ServiceProvider
             'JavaScript',
             'Laracasts\Utilities\JavaScript\JavaScriptFacade'
         );
+
+        if(config('javascript.ng_module')) {
+            AliasLoader::getInstance()->alias(
+                'Angular',
+                'Laracasts\Utilities\JavaScript\AngularFacade'
+            );
+        }
     }
 
 }

--- a/src/JavascriptServiceProvider.php
+++ b/src/JavascriptServiceProvider.php
@@ -34,6 +34,7 @@ class JavaScriptServiceProvider extends ServiceProvider
             $this->app->bind('Angular', function ($app) {
                 $view = config('javascript.bind_js_vars_to_this_view');
                 $module = config('javascript.ng_module');
+                $constant = config('javascript.ng_constant');
 
                 if (is_null($view)) {
                     throw new JavaScriptException;
@@ -41,7 +42,7 @@ class JavaScriptServiceProvider extends ServiceProvider
 
                 $binder = new LaravelViewBinder($app['events'], $view);
 
-                return new PHPToAngularTransformer($binder, $module);
+                return new PHPToAngularTransformer($binder, $module, $constant);
             });
         }
     }

--- a/src/PHPToAngularTransformer.php
+++ b/src/PHPToAngularTransformer.php
@@ -49,33 +49,21 @@ class PHPToAngularTransformer extends PHPToJavaScriptTransformer
      */
     public function buildJavaScriptSyntax(array $vars)
     {
-        $js = $this->buildModule();
-        $js .= $this->buildConstant($vars);
-        $js .= ';';
-
-        return $js;
+        return $this->buildNgConstant($vars);
     }
 
     /**
-     * Create the module that all
-     * constants will be nested under.
-     *
-     * @return string
-     */
-    protected function buildModule()
-    {
-        return "angular.module('{$this->module}')";
-    }
-
-    /**
-     * Translate a single PHP var to an Angular constant.
+     * Translate PHP vars array to an Angular constant.
      *
      * @param  array $vars
      * @return string
      */
-    protected function buildConstant($vars)
+    protected function buildNgConstant($vars)
     {
-        return ".constant('{$this->constant}', {$this->optimizeValueForJavaScript($vars)});";
+        $js = "angular.module('{$this->module}')";
+        $js .= ".constant('{$this->constant}', {$this->transformArray($vars)});";
+
+        return $js;
     }
 
 } 

--- a/src/PHPToAngularTransformer.php
+++ b/src/PHPToAngularTransformer.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Laracasts\Utilities\JavaScript;
+
+class PHPToAngularTransformer extends PHPToJavaScriptTransformer
+{
+
+    /**
+     * The module to nest the constants under.
+     *
+     * @var string
+     */
+    protected $module;
+
+    /**
+     * What binds the variables to the views.
+     *
+     * @var ViewBinder
+     */
+    protected $viewBinder;
+
+    /**
+     * Create a new JS transformer instance.
+     *
+     * @param ViewBinder $viewBinder
+     * @param string     $module
+     */
+    function __construct(ViewBinder $viewBinder, $module = 'app')
+    {
+        $this->viewBinder = $viewBinder;
+        $this->module = $module;
+    }
+
+    /**
+     * Translate the array of PHP vars to
+     * the expected JavaScript syntax.
+     *
+     * @param  array $vars
+     * @return array
+     */
+    public function buildJavaScriptSyntax(array $vars)
+    {
+        $js = $this->buildModule();
+
+        foreach ($vars as $key => $value) {
+            $js .= $this->buildConstant($key, $value);
+        }
+
+        return $js;
+    }
+
+    /**
+     * Create the module that all
+     * constants will be nested under.
+     *
+     * @return string
+     */
+    protected function buildModule()
+    {
+        return "angular.module('{$this->module}')";
+    }
+
+    /**
+     * Translate a single PHP var to an Angular constant.
+     *
+     * @param  string $key
+     * @param  string $value
+     * @return string
+     */
+    protected function buildConstant($key, $value)
+    {
+        return ".constant('{$key}', {$this->optimizeValueForJavaScript($value)});";
+    }
+
+} 

--- a/src/PHPToAngularTransformer.php
+++ b/src/PHPToAngularTransformer.php
@@ -20,15 +20,24 @@ class PHPToAngularTransformer extends PHPToJavaScriptTransformer
     protected $viewBinder;
 
     /**
-     * Create a new JS transformer instance.
+     * The name of the constant.
+     *
+     * @var string
+     */
+    private $constant;
+
+    /**
+     * Create a new Angular transformer instance.
      *
      * @param ViewBinder $viewBinder
      * @param string     $module
+     * @param string     $constant
      */
-    function __construct(ViewBinder $viewBinder, $module = 'app')
+    function __construct(ViewBinder $viewBinder, $module = 'app', $constant = 'DATA')
     {
         $this->viewBinder = $viewBinder;
         $this->module = $module;
+        $this->constant = $constant;
     }
 
     /**
@@ -41,10 +50,8 @@ class PHPToAngularTransformer extends PHPToJavaScriptTransformer
     public function buildJavaScriptSyntax(array $vars)
     {
         $js = $this->buildModule();
-
-        foreach ($vars as $key => $value) {
-            $js .= $this->buildConstant($key, $value);
-        }
+        $js .= $this->buildConstant($vars);
+        $js .= ';';
 
         return $js;
     }
@@ -63,13 +70,12 @@ class PHPToAngularTransformer extends PHPToJavaScriptTransformer
     /**
      * Translate a single PHP var to an Angular constant.
      *
-     * @param  string $key
-     * @param  string $value
+     * @param  array $vars
      * @return string
      */
-    protected function buildConstant($key, $value)
+    protected function buildConstant($vars)
     {
-        return ".constant('{$key}', {$this->optimizeValueForJavaScript($value)});";
+        return ".constant('{$this->constant}', {$this->optimizeValueForJavaScript($vars)});";
     }
 
 } 

--- a/src/config/javascript.php
+++ b/src/config/javascript.php
@@ -38,6 +38,16 @@ return [
     | This will also activate the Angular service.
     |
     */
-    'ng_module' => false
+    'ng_module' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Angular Constant Name
+    |--------------------------------------------------------------------------
+    |
+    | The name of the Angular constant we are attaching the data to.
+    |
+    */
+    'ng_constant' => 'DATA'
 
 ];

--- a/src/config/javascript.php
+++ b/src/config/javascript.php
@@ -25,6 +25,19 @@ return [
     | That way, you can access vars, like "SomeNamespace.someVariable."
     |
     */
-    'js_namespace' => 'window'
+    'js_namespace' => 'window',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Angular Module
+    |--------------------------------------------------------------------------
+    |
+    | By default, we disable the Angular constants service. If you would like
+    | to export your PHP vars to Angular constants, you will want to change
+    | this to the Angular module that you want to bind your constants to.
+    | This will also activate the Angular service.
+    |
+    */
+    'ng_module' => false
 
 ];


### PR DESCRIPTION
This adds the ability to export PHP vars to an Angular constant.  I've updated the README file showing example of how this works.  Here is a quick explanation...

This:

```php
Angular::put([
    'foo' => 'bar',
    'age' => 29
]);
```

Turns into this:

```js
angular.module('myApp').constant('DATA', {'foo', 'bar', 'age': 29});
```

Of course the module and constant name are configurable.  I've also made the module config `false` by default, which skips loading the Angular service altogether.