### PR TITLE
Fix newline in input string to generate invalid javascript

### DIFF
--- a/spec/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformerSpec.php
+++ b/spec/Laracasts/Utilities/JavaScript/PHPToJavaScriptTransformerSpec.php
@@ -56,10 +56,26 @@ class PHPToJavaScriptTransformerSpec extends ObjectBehavior
              ->shouldMatch("/window.foo = 'bar';/");
     }
 
+    function it_transforms_multiline_php_strings()
+    {
+        $this->buildJavaScriptSyntax(['foo' => "new\nline"])
+             ->shouldContain('\n'); // String
+        $this->buildJavaScriptSyntax(['foo' => "new\nline"])
+             ->shouldNotContain("\n"); // Newline character
+    }
+
     function it_transforms_php_arrays()
     {
         $this->buildJavaScriptSyntax(['letters' => ['a', 'b']])
              ->shouldMatch('/window.letters = \["a","b"\];/');
+    }
+
+    function it_transforms_multiline_strings_in_php_arrays()
+    {
+        $this->buildJavaScriptSyntax(['newline' => ["new\nline"]])
+             ->shouldContain('\n'); // String
+        $this->buildJavaScriptSyntax(['newline' => ["new\nline"]])
+             ->shouldNotContain("\n"); // Newline character
     }
 
     function it_transforms_php_booleans()

--- a/src/PHPToJavaScriptTransformer.php
+++ b/src/PHPToJavaScriptTransformer.php
@@ -243,6 +243,6 @@ class PHPToJavaScriptTransformer
      */
     protected function escape($value)
     {
-        return str_replace(["\\", "'"], ["\\\\", "\'"], $value);
+        return str_replace(["\\", "'", "\n"], ["\\\\", "\'", "\\n"], $value);
     }
 }


### PR DESCRIPTION
When the input string contains newline characters the generated javascript is invalid as strings in javascript can't span multiple lines. (related: #52)

Here I'm just escaping newline characters "\n" so the generated javascript contains the actual "\\" and "n" characters, then javascript will interpret that as the newline character... this is really strange to try and explain xD
