### PR TITLE
Build only one transformer, depending on value type

### DIFF
--- a/src/Transformers/BooleanTransformer.php
+++ b/src/Transformers/BooleanTransformer.php
@@ -12,8 +12,6 @@ class BooleanTransformer
      */
     public function transform($value)
     {
-        if (is_bool($value)) {
-            return $value ? 'true' : 'false';
-        }
+        return $value ? 'true' : 'false';
     }
 }

--- a/src/Transformers/DoubleTransformer.php
+++ b/src/Transformers/DoubleTransformer.php
@@ -2,16 +2,16 @@
 
 namespace Laracasts\Utilities\JavaScript\Transformers;
 
-class ArrayTransformer
+class DoubleTransformer
 {
     /**
-     * Transform an array.
+     * Transform a double value.
      *
-     * @param  array $value
-     * @return string
+     * @param  mixed $value
+     * @return mixed
      */
     public function transform($value)
     {
-        return json_encode($value);
+        return $value;
     }
 }

--- a/src/Transformers/IntegerTransformer.php
+++ b/src/Transformers/IntegerTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Laracasts\Utilities\JavaScript\Transformers;
 
-class NumericTransformer
+class IntegerTransformer
 {
     /**
      * Transform a numeric value.
@@ -12,8 +12,6 @@ class NumericTransformer
      */
     public function transform($value)
     {
-        if (is_numeric($value)) {
-            return $value;
-        }
+        return $value;
     }
 }

--- a/src/Transformers/NullTransformer.php
+++ b/src/Transformers/NullTransformer.php
@@ -12,8 +12,6 @@ class NullTransformer
      */
     public function transform($value)
     {
-        if (is_null($value)) {
-            return 'null';
-        }
+        return 'null';
     }
 }

--- a/src/Transformers/ObjectTransformer.php
+++ b/src/Transformers/ObjectTransformer.php
@@ -16,10 +16,6 @@ class ObjectTransformer
      */
     public function transform($value)
     {
-        if (! is_object($value)) {
-            return;
-        }
-
         if ($value instanceof JsonSerializable || $value instanceof StdClass) {
             return json_encode($value);
         }

--- a/src/Transformers/StringTransformer.php
+++ b/src/Transformers/StringTransformer.php
@@ -12,9 +12,7 @@ class StringTransformer
      */
     public function transform($value)
     {
-        if (is_string($value)) {
-            return "'{$this->escape($value)}'";
-        }
+        return "'{$this->escape($value)}'";
     }
 
     /**

--- a/src/Transformers/Transformer.php
+++ b/src/Transformers/Transformer.php
@@ -99,7 +99,7 @@ class Transformer
      */
     protected function convertToJavaScript($value)
     {
-        $class = 'Laracasts\\Utilities\\JavaScript\\Transformers\\' . ucfirst(gettype($value)) . 'Transformer';
+        $class = 'Laracasts\\Utilities\\JavaScript\\Transformers\\' . ucfirst(strtolower(gettype($value))) . 'Transformer';
 
         return (new $class)->transform($value);
     }

--- a/src/Transformers/Transformer.php
+++ b/src/Transformers/Transformer.php
@@ -22,20 +22,6 @@ class Transformer
     protected $viewBinder;
 
     /**
-     * All transformable types.
-     *
-     * @var array
-     */
-    protected $transformers = [
-        StringTransformer::class,
-        ArrayTransformer::class,
-        ObjectTransformer::class,
-        NumericTransformer::class,
-        BooleanTransformer::class,
-        NullTransformer::class
-    ];
-
-    /**
      * Create a new JS transformer instance.
      *
      * @param ViewBinder $viewBinder
@@ -113,13 +99,9 @@ class Transformer
      */
     protected function convertToJavaScript($value)
     {
-        foreach ($this->transformers as $transformer) {
-            $js = (new $transformer)->transform($value);
+        $class = 'Laracasts\\Utilities\\JavaScript\\Transformers\\' . ucfirst(gettype($value)) . 'Transformer';
 
-            if (! is_null($js)) {
-                return $js;
-            }
-        }
+        return (new $class)->transform($value);
     }
 
     /**


### PR DESCRIPTION
This PR makes sure only one transformer class ever gets instantiated.

Prior to this, say a boolean had to be transformed - 5 different transformers would get instantiated before returning the result.