### PR TITLE
Avoid using tap() for PHP 5.5 compatibility

### DIFF
--- a/src/Transformers/Transformer.php
+++ b/src/Transformers/Transformer.php
@@ -38,9 +38,11 @@ class Transformer
      */
     public function put()
     {
-        return tap($this->constructJavaScript($this->normalizeInput(func_get_args())), function ($js) {
-            $this->viewBinder->bind($js);
-        });
+        $js = $this->constructJavaScript($this->normalizeInput(func_get_args()));
+
+        $this->viewBinder->bind($js);
+
+        return $js;
     }
 
     /**


### PR DESCRIPTION
`tap()` was first used here: 546db3faa2bf1a443dade32cb6689cbd729b7d3e

Doing `composer install` using PHP 5.5 would result in having latest `5.2.*` version of `illuminate/support` installed, which does not include `tap()`, therefore the tests for PHP 5.5 would fail.

This PR implements a simple code change to avoid using `tap()`.

Alternative approach was dropping support for PHP 5.5, which I don't believe was a better call at the moment due to a small code change required.