### PR TITLE
Fix PHPStorm Intellisense for put() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "illuminate/support": "~5.0"
     },
     "require-dev": {

--- a/src/Transformers/Transformer.php
+++ b/src/Transformers/Transformer.php
@@ -35,10 +35,13 @@ class Transformer
 
     /**
      * Bind the given array of variables to the view.
+     *
+     * @param  mixed ...$args
+     * @return array
      */
-    public function put()
+    public function put(...$args)
     {
-        $js = $this->constructJavaScript($this->normalizeInput(func_get_args()));
+        $js = $this->constructJavaScript($this->normalizeInput($args));
 
         $this->viewBinder->bind($js);
 


### PR DESCRIPTION
PHPStorm complains about passes arguments to a function with no parameters. This is because the `put()` method uses `func_get_args()` to dynamically retrieve args from the caller.

I followed the suggestion on this [Stack Overflow answer](https://stackoverflow.com/questions/14513356/phpdoc-documenting-a-function-with-a-variable-number-of-arguments) and it fixes the issue. I am also using Laravel IDE helper.