### PR TITLE
Support HTML Attributes on <script> Tag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,14 @@ For Laravel users, there is a service provider you can make use of to automatica
 
 When this provider is booted, you'll gain access to a helpful `JavaScript` facade, which you may use in your controllers.
 
+## Usage
+
+#### JavaScript::put(...)
+
+The `JavaScript` facade has two public functions. The first/main one is `JavaScript::put(...)`, which transforms the given PHP data and passes it to the front-end view file.
+
+For example:
+
 ```php
 public function index()
 {
@@ -61,7 +69,7 @@ console.log(age); // 29
 
 This package, by default, binds your JavaScript variables to a "footer" view, which you will include. For example:
 
-```
+```blade
 <body>
     <h1>My Page</h1>
 
@@ -69,9 +77,42 @@ This package, by default, binds your JavaScript variables to a "footer" view, wh
 </body>
 ```
 
-Naturally, you can change this default to a different view. See below.
+Naturally, you can change this default to a different view. See ["Defaults"](#defaults) below.
 
-### Defaults
+#### JavaScript::setHtmlAttributes(...)
+
+The second public function provided by this facade is `JavaScript::setHtmlAttributes(...)`, which allows you to set the element attributes on the HTML `<script>` tag(s).
+For example, if you need to add nonces to your script tags for your Content Security Policy, you can pass the attribute it in as an array:
+
+```php
+public function index()
+{
+  JavaScript::setHtmlAttributes([
+    'nonce' => csp_nonce(), // `csp_nonce()` is NOT provided by this package
+  ]);
+
+  JavaScript::put([
+    'foo' => 'bar'
+  ]);
+
+  return View::make('hello');
+}
+```
+
+The above `JavaScript` calls would output something like this in the view file:
+```html
+<body>
+  <script nonce="This_Is_A_Secure_Nonce">
+      JS.foo = "bar";
+  </script>
+</body>
+```
+
+> **NOTE**: This package does not provide any sort of Content Security Policy logic; the above is just an example of an additional HTML attribute you may need to add.
+> For more information on Content Security Policy, see [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+> If you do not already have CSP and are using Laravel, I would recommend package [spatie/laravel-csp](https://github.com/spatie/laravel-csp).
+
+## Defaults
 
 If using Laravel, there are only two configuration options that you'll need to worry about. First, publish the default configuration.
 

--- a/readme.md
+++ b/readme.md
@@ -69,19 +69,20 @@ console.log(age); // 29
 
 This package, by default, binds your JavaScript variables to a "footer" view, which you will include. For example:
 
-```blade
+```html
 <body>
     <h1>My Page</h1>
 
-    @include ('footer') // <-- Variables prepended to this view
+    <!-- Variables prepended to this view -->
+    @include ('footer')
 </body>
 ```
 
 Naturally, you can change this default to a different view. See ["Defaults"](#defaults) below.
 
-#### JavaScript::setHtmlAttributes(...)
+#### JavaScript::setHtmlAttributes($htmlAttributes)
 
-The second public function provided by this facade is `JavaScript::setHtmlAttributes(...)`, which allows you to set the element attributes on the HTML `<script>` tag(s).
+The second public function provided by this facade is `JavaScript::setHtmlAttributes($htmlAttributes)`, which allows you to set the element attributes on the HTML `<script>` tag(s).
 For example, if you need to add nonces to your script tags for your Content Security Policy, you can pass the attributes in as an array:
 
 ```php
@@ -109,7 +110,9 @@ The above `JavaScript` calls would output something like this in the compiled vi
 ```
 
 > **NOTE**: This package does not provide any sort of Content Security Policy logic; the above is just an example of an additional HTML attribute you may need to add to a script tag.
+>
 > For more information on Content Security Policy, see [the Mozilla Developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+>
 > If you do not already have CSP and are using Laravel, I would recommend package [spatie/laravel-csp](https://github.com/spatie/laravel-csp).
 
 ## Defaults

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Naturally, you can change this default to a different view. See ["Defaults"](#de
 #### JavaScript::setHtmlAttributes(...)
 
 The second public function provided by this facade is `JavaScript::setHtmlAttributes(...)`, which allows you to set the element attributes on the HTML `<script>` tag(s).
-For example, if you need to add nonces to your script tags for your Content Security Policy, you can pass the attribute it in as an array:
+For example, if you need to add nonces to your script tags for your Content Security Policy, you can pass the attributes in as an array:
 
 ```php
 public function index()
@@ -99,7 +99,7 @@ public function index()
 }
 ```
 
-The above `JavaScript` calls would output something like this in the view file:
+The above `JavaScript` calls would output something like this in the compiled view file:
 ```html
 <body>
   <script nonce="This_Is_A_Secure_Nonce">
@@ -108,8 +108,8 @@ The above `JavaScript` calls would output something like this in the view file:
 </body>
 ```
 
-> **NOTE**: This package does not provide any sort of Content Security Policy logic; the above is just an example of an additional HTML attribute you may need to add.
-> For more information on Content Security Policy, see [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+> **NOTE**: This package does not provide any sort of Content Security Policy logic; the above is just an example of an additional HTML attribute you may need to add to a script tag.
+> For more information on Content Security Policy, see [the Mozilla Developer docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
 > If you do not already have CSP and are using Laravel, I would recommend package [spatie/laravel-csp](https://github.com/spatie/laravel-csp).
 
 ## Defaults

--- a/src/LaravelViewBinder.php
+++ b/src/LaravelViewBinder.php
@@ -21,15 +21,53 @@ class LaravelViewBinder implements ViewBinder
     protected $views;
 
     /**
+     * An array of HTML attributes to add to the <script> tag(s)
+     *
+     * @var array
+     */
+    protected $htmlAttributes;
+
+    /**
      * Create a new Laravel view binder instance.
      *
      * @param Dispatcher   $event
      * @param string|array $views
+     * @param array        $attributes
      */
-    public function __construct(Dispatcher $event, $views)
+    public function __construct(Dispatcher $event, $views, $htmlAttributes = [])
     {
-        $this->event = $event;
-        $this->views = str_replace('/', '.', (array)$views);
+        $this->event          = $event;
+        $this->views          = str_replace('/', '.', (array)$views);
+        $this->htmlAttributes = $htmlAttributes;
+    }
+
+    /**
+     * Set the array of HTML attributes
+     *
+     * @param array $htmlAttributes
+     */
+    public function setHtmlAttributes(array $htmlAttributes)
+    {
+        $this->htmlAttributes = $htmlAttributes;
+    }
+
+    /**
+     * Get the list of HTML attributes, as an array or an HTML-ready string
+     *
+     * @param boolean $toString should we return the attributes as a string?
+     * @return array|string
+     */
+    protected function getHtmlAttributes($toString = false)
+    {
+        if ($toString === false) {
+          return $this->htmlAttributes;
+        }
+
+        $out = "";
+        foreach ($this->htmlAttributes as $attribute => $value) {
+            $out .= " {$attribute}=\"{$value}\"";
+        }
+        return $out;
     }
 
     /**
@@ -39,9 +77,10 @@ class LaravelViewBinder implements ViewBinder
      */
     public function bind($js)
     {
+        $htmlAttributes = $this->getHtmlAttributes(true);
         foreach ($this->views as $view) {
-            $this->event->listen("composing: {$view}", function () use ($js) {
-                echo "<script>{$js}</script>";
+            $this->event->listen("composing: {$view}", function () use ($htmlAttributes, $js) {
+                echo "<script{$htmlAttributes}>{$js}</script>";
             });
         }
     }

--- a/src/Transformers/Transformer.php
+++ b/src/Transformers/Transformer.php
@@ -46,6 +46,16 @@ class Transformer
     }
 
     /**
+     * Add HTML attributes to the <script> tag(s)
+     *
+     * @param array $attributes an associative array of attributes and values to add
+     */
+    public function setHtmlAttributes(array $attributes)
+    {
+        $this->viewBinder->setHtmlAttributes($attributes);
+    }
+
+    /**
      * Translate the array of PHP variables to a JavaScript syntax.
      *
      * @param  array $variables

--- a/src/ViewBinder.php
+++ b/src/ViewBinder.php
@@ -10,4 +10,12 @@ interface ViewBinder
      * @param string $js
      */
     public function bind($js);
+
+
+    /**
+     * Set the array of HTML attributes for the <script> tag(s)
+     *
+     * @param array $htmlAttributes associative array of HTML element attributes
+     */
+    public function setHtmlAttributes(array $htmlAttributes);
 }


### PR DESCRIPTION
In certain cases, a user of this package might need to add one or more HTML attributes to the `<script>` tag outputted in the compiled view file. For example, if CSP headers are set up for the site, you need to add nonces to inline `<script>` tags so that the browser allows them to execute.

This is achieved by adding a new function to the `ViewBinder` and `Transformer` classes: `setHtmlAttributes(array $attributes)`.

If this method is called, the `ViewBinder->bind()` method will include the attributes that were given to the `setHtmlAttributes` function.

For example:
```php
\JavaScript::setHtmlAttributes(['foo' => 'bar']);
\JavaScript::put(['fizz' => 'buzz']);
```
Will result in the following output in the HTML file:
```html
<script foo="bar">
   JS.fizz = "buzz";
</script>
```
