### PR TITLE
only add js (checked by hash) once - to prevent multiple listeners ad…

### DIFF
--- a/src/LaravelViewBinder.php
+++ b/src/LaravelViewBinder.php
@@ -34,14 +34,23 @@ class LaravelViewBinder implements ViewBinder
 
     /**
      * Bind the given JavaScript to the view.
+     * Tracks if Javascript has already been added
+     * by keeping hashes of the js code to check against in the view data
      *
      * @param string $js
      */
     public function bind($js)
     {
         foreach ($this->views as $view) {
-            $this->event->listen("composing: {$view}", function () use ($js) {
-                echo "<script>{$js}</script>";
+            $this->event->listen("composing: {$view}", function ($view) use ($js) {
+                $data = $view->getData();
+                $hashes = isset($data['hashes']) ? $data['hashes'] : [];
+                $hash = md5($js);
+                if (!in_array($hash,$hashes)) {
+                    $hashes[] = md5($js);
+                    $view->with('hashes',$hashes);
+                    echo "<script>{$js}</script>";
+                }
             });
         }
     }


### PR DESCRIPTION
This solves issue https://github.com/laracasts/PHP-Vars-To-Js-Transformer/issues/110

Queued tasks add the JS code multiple times. The fix keeps track of each js that is to be added with an array with hashes in the `$view` data. If there already is a hash for the js code, skip it. It seems todo the trick.

It's not really a solution to the problem that the queue is adding multiple (unnecessary) listeners, but it is a failsafe.